### PR TITLE
Couple of powernv / powerpc - related fixes

### DIFF
--- a/target-ppc/mmu-hash64.c
+++ b/target-ppc/mmu-hash64.c
@@ -666,7 +666,7 @@ static void ppc_hash64_set_dsi(CPUState *cs, CPUPPCState *env, uint64_t dar, uin
     } else {
         vpm = !!(env->spr[SPR_LPCR] & LPCR_VPM0);
     }
-    if (vpm && msr_hv) {
+    if (vpm && !msr_hv) {
         cs->exception_index = POWERPC_EXCP_HDSI;
         env->spr[SPR_HDAR] = dar;
         env->spr[SPR_HDSISR] = dsisr;


### PR DESCRIPTION
I think there is still a bug in 3e4d73f, in ppc_hash64_set_dsi shouldn't the if (vpm && msr_hv) be if (vpm && !msr_hv) instead??

Also quench the invalid / priviledged messages if we're doing something that obviously involves trapping such accesses (i.e. MSR.HV and MSR.PR on).

A
